### PR TITLE
Enable CORS for local React development

### DIFF
--- a/MealMate-backend/Program.cs
+++ b/MealMate-backend/Program.cs
@@ -19,6 +19,16 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowLocalhostReact", policy =>
+        policy.WithOrigins(
+                "http://localhost:3000",
+                "http://127.0.0.1:3000")
+            .AllowAnyHeader()
+            .AllowAnyMethod());
+});
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -28,6 +38,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors("AllowLocalhostReact");
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- add a CORS policy that allows the local React development server to reach the API
- apply the CORS policy in the middleware pipeline

## Testing
- Not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfba09c280833082dfd3440494fa36